### PR TITLE
Jansthcirlu/implement-start-and-finish-work-queue

### DIFF
--- a/ActorGraphs/BreadthFirstSearchActor.cs
+++ b/ActorGraphs/BreadthFirstSearchActor.cs
@@ -85,8 +85,17 @@ public sealed class BreadthFirstSearchActor<TNode, TValue, TEdge, TWeight> : Act
             BreadthFirstSearchMessage.UpdateWeightMessage<TValue, TWeight> message =
                 BreadthFirstSearchMessage.UpdateTotalWeight(Id, updateWeightMessage.StartValue, TotalWeightFromStart.Value); // Total weight is never null here
 
-            // Start sending
+            // Create a task ID for the messaging work
+            Guid taskId = Guid.NewGuid();
+
+            // Notify the runner that work has started
+            await Runner.SendAsync(BreadthFirstSearchRunnerMessage.WorkStarted(Id, taskId));
+
+            // Message neighbours (do work)
             await NotifyNeighbours(message);
+
+            // Notify the runner that work has finished
+            await Runner.SendAsync(BreadthFirstSearchRunnerMessage.WorkFinished(Id, taskId));
         }
     }
 

--- a/ActorGraphs/BreadthFirstSearchActor.cs
+++ b/ActorGraphs/BreadthFirstSearchActor.cs
@@ -55,12 +55,15 @@ public sealed class BreadthFirstSearchActor<TNode, TValue, TEdge, TWeight> : Act
         if (startMessage.SenderId is not BreadthFirstSearchRunnerId runnerId) return;
         if (!runnerId.Equals(Runner)) return;
 
+        // Expect start node value to be equal to own node value
+        if (!Node.Value.Equals(startMessage.StartValue)) return;
+
         // Initialize own weight to "zero"
         TotalWeightFromStart = TWeight.AdditiveIdentity;
 
         // Create update weight message
         BreadthFirstSearchMessage.UpdateWeightMessage<TValue, TWeight> updateWeightMessage =
-            BreadthFirstSearchMessage.UpdateTotalWeight(Id, startMessage.StartValue, TotalWeightFromStart.Value);
+            BreadthFirstSearchMessage.UpdateTotalWeight(Id, startMessage.StartValue, TotalWeightFromStart!.Value);
 
         // Start sending
         await NotifyNeighbours(updateWeightMessage);

--- a/ActorGraphs/BreadthFirstSearchRunnerMessage.cs
+++ b/ActorGraphs/BreadthFirstSearchRunnerMessage.cs
@@ -7,16 +7,16 @@ public abstract record BreadthFirstSearchRunnerMessage(IActorId SenderId) : IMes
 {
     public sealed record TotalWeightFromStartMessage<TWeight>(IActorId SenderId, TWeight? TotalWeight) : BreadthFirstSearchRunnerMessage(SenderId)
         where TWeight : struct, IComparable<TWeight>, IAdditionOperators<TWeight, TWeight, TWeight>, IAdditiveIdentity<TWeight, TWeight>;
-    public sealed record StartedWorkMessage(IActorId SenderId) : BreadthFirstSearchRunnerMessage(SenderId);
-    public sealed record FinishedWorkMessage(IActorId SenderId) : BreadthFirstSearchRunnerMessage(SenderId);
+    public sealed record StartedWorkMessage(IActorId SenderId, Guid TaskId) : BreadthFirstSearchRunnerMessage(SenderId);
+    public sealed record FinishedWorkMessage(IActorId SenderId, Guid TaskId) : BreadthFirstSearchRunnerMessage(SenderId);
 
     public static TotalWeightFromStartMessage<TWeight> SendTotalWeight<TWeight>(IActorId senderId, TWeight? totalWeight)
         where TWeight : struct, IComparable<TWeight>, IAdditionOperators<TWeight, TWeight, TWeight>, IAdditiveIdentity<TWeight, TWeight>
         => new(senderId, totalWeight);
 
-    public static StartedWorkMessage WorkStarted(IActorId senderId)
-        => new(senderId);
+    public static StartedWorkMessage WorkStarted(IActorId senderId, Guid taskId)
+        => new(senderId, taskId);
 
-    public static FinishedWorkMessage WorkFinished(IActorId senderId)
-        => new(senderId);
+    public static FinishedWorkMessage WorkFinished(IActorId senderId, Guid taskId)
+        => new(senderId, taskId);
 }


### PR DESCRIPTION
Actors can signal to their runner when they've started working and when they've finished working. The runner keeps track of this under the assumption that started work will always trigger more work before it finishes, or the triggered work will complete immediately. Using a task completion source, the runner can signal to itself when the search run itself has finished.