### PR TITLE
Jansthcirlu/finish-when-no-neighbours

### DIFF
--- a/ActorGraphs/BreadthFirstSearchRunnerMessage.cs
+++ b/ActorGraphs/BreadthFirstSearchRunnerMessage.cs
@@ -9,6 +9,9 @@ public abstract record BreadthFirstSearchRunnerMessage(IActorId SenderId) : IMes
         where TWeight : struct, IComparable<TWeight>, IAdditionOperators<TWeight, TWeight, TWeight>, IAdditiveIdentity<TWeight, TWeight>;
     public sealed record StartedWorkMessage(IActorId SenderId, Guid TaskId) : BreadthFirstSearchRunnerMessage(SenderId);
     public sealed record FinishedWorkMessage(IActorId SenderId, Guid TaskId) : BreadthFirstSearchRunnerMessage(SenderId);
+    public sealed record NoNeighboursMessage<TValue>(IActorId SenderId, TValue ActorNodeValue) : BreadthFirstSearchRunnerMessage(SenderId);
+    public sealed record RunFinishedMessage(IActorId SenderId) : BreadthFirstSearchRunnerMessage(SenderId);
+    public sealed record RunFinishedImmediatelyMessage<TValue>(IActorId SenderId, TValue StartValue) : BreadthFirstSearchRunnerMessage(SenderId);
 
     public static TotalWeightFromStartMessage<TWeight> SendTotalWeight<TWeight>(IActorId senderId, TWeight? totalWeight)
         where TWeight : struct, IComparable<TWeight>, IAdditionOperators<TWeight, TWeight, TWeight>, IAdditiveIdentity<TWeight, TWeight>
@@ -19,4 +22,13 @@ public abstract record BreadthFirstSearchRunnerMessage(IActorId SenderId) : IMes
 
     public static FinishedWorkMessage WorkFinished(IActorId senderId, Guid taskId)
         => new(senderId, taskId);
+
+    public static NoNeighboursMessage<TValue> NoNeighbours<TValue>(IActorId senderId, TValue actorNodeValue)
+        => new(senderId, actorNodeValue);
+
+    public static RunFinishedMessage RunFinished(IActorId senderId)
+        => new(senderId);
+
+    public static RunFinishedImmediatelyMessage<TValue> RunFinishedImmediately<TValue>(IActorId senderId, TValue startValue)
+        => new(senderId, startValue);
 }


### PR DESCRIPTION
Added logic to signal when a run should finish in a more granular way. If an actor has no neighbours, they signal this and the runner finishes with just one node in the distance dictionary. If the run ends normally, i.e. based on actor activity, then the runner queries every actor for their distance before signalling to themselves that they should finish the run.